### PR TITLE
DAO Option with Base91 encoding in Beacon Message

### DIFF
--- a/data/tracker.json
+++ b/data/tracker.json
@@ -1,6 +1,7 @@
 {
 	"callsign":"NOCALL-7",
 	"debug": false,
+	"enhance_precision": true,
 	"beacon":
 	{
 		"message":"LoRa Tracker",

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -43,7 +43,7 @@ Configuration ConfigurationManagement::readConfiguration()
 	if(data.containsKey("callsign"))
 		conf.callsign				= data["callsign"].as<String>();
 	conf.debug						= data["debug"]								| false;
-
+	conf.enhance_precision			= data["enhance_precision"]					| false;
 	if(data.containsKey("beacon") && data["beacon"].containsKey("message"))
 		conf.beacon.message			= data["beacon"]["message"].as<String>();
 	conf.beacon.timeout				= data["beacon"]["timeout"]					| 1;
@@ -84,6 +84,7 @@ void ConfigurationManagement::writeConfiguration(Configuration conf)
 
 	data["callsign"]						= conf.callsign;
 	data["debug"]							= conf.debug;
+	data["enhance_precision"]				= conf.enhance_precision;
 	data["beacon"]["message"]				= conf.beacon.message;
 	data["beacon"]["timeout"]				= conf.beacon.timeout;
 	data["beacon"]["symbol"]				= conf.beacon.symbol;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -47,7 +47,7 @@ public:
 		int codingRate4;
 	};
 
-	Configuration() : callsign("NOCALL-10"), debug(false) {};
+	Configuration() : callsign("NOCALL-10"), debug(false), enhance_precision(true) {};
 
 	String callsign;
 	bool debug;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -51,6 +51,7 @@ public:
 
 	String callsign;
 	bool debug;
+	bool enhance_precision;
 	Beacon beacon;
 	Smart_Beacon smart_beacon;
 	LoRa lora;


### PR DESCRIPTION
Added APRS Datum and Precision Option to Beacon Message.
This offers two more digits Precision for Lat/Lon in Position Reports.
Spec: http://www.aprs.org/aprs12/datum.txt

I Hope this was implemented ok? Seems to work.
Got some great help from:
https://metacpan.org/dist/Ham-APRS-FAP/source/FAP.pm

