### PR TITLE
Enable manual TX with the middle GPIO button

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The best success is to use PlatformIO (and it is the only platform where I can s
 ### Configuration
 
 * You can find all nessesary settings to change for your configuration in **data/tracker.json**.
+* The `button_tx` setting enables manual triggering of the beacon using the middle button on the T-Beam.
 * To upload it to your board you have to do this via **Upload File System image** in PlatformIO!
 * To find the 'Upload File System image' click the PlatformIO symbol (the little alien) on the left side, choos your configuration, click on 'Platform' and search for 'Upload File System image'.
 

--- a/data/tracker.json
+++ b/data/tracker.json
@@ -6,6 +6,7 @@
 	{
 		"message":"LoRa Tracker",
 		"timeout": 1,
+		"button_tx": false,
 		"symbol": "[",
 		"overlay": "/"
 	},

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ lib_deps =
 	peterus/APRS-Decoder-Lib @ 0.0.5
 	mikalhart/TinyGPSPlus @ 1.0.2
 	paulstoffregen/Time @ 1.6
+	shaggydog/OneButton @ 1.5.0
 check_tool = cppcheck
 check_flags =
 	cppcheck: --suppress=*:*.pio\* --inline-suppr -DCPPCHECK

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -51,6 +51,8 @@ Configuration ConfigurationManagement::readConfiguration()
 		conf.beacon.symbol			= data["beacon"]["symbol"].as<String>();
 	if(data.containsKey("beacon") && data["beacon"].containsKey("overlay"))
 		conf.beacon.overlay			= data["beacon"]["overlay"].as<String>() ;
+	if(data.containsKey("beacon") && data["beacon"].containsKey("button_tx"))
+		conf.beacon.button_tx			= data["beacon"]["button_tx"]			| false;
 
 	conf.smart_beacon.active		= data["smart_beacon"]["active"]			| false;
 	conf.smart_beacon.turn_min		= data["smart_beacon"]["turn_min"]			| 25;
@@ -95,6 +97,7 @@ void ConfigurationManagement::writeConfiguration(Configuration conf)
 	data["beacon"]["timeout"]				= conf.beacon.timeout;
 	data["beacon"]["symbol"]				= conf.beacon.symbol;
 	data["beacon"]["overlay"]				= conf.beacon.overlay;
+	data["beacon"]["button_tx"]				= conf.beacon.button_tx;
 	data["smart_beacon"]["active"]			= conf.smart_beacon.active;  
 	data["smart_beacon"]["turn_min"] 		= conf.smart_beacon.turn_min;	
 	data["smart_beacon"]["slow_rate"]		= conf.smart_beacon.slow_rate;	

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -11,12 +11,13 @@ public:
 	class Beacon
 	{
 	public:
-		Beacon() : message("LoRa Tracker, Info: github.com/lora-aprs/LoRa_APRS_Tracker"), timeout(1), symbol("["), overlay("/") {}
+		Beacon() : message("LoRa Tracker, Info: github.com/lora-aprs/LoRa_APRS_Tracker"), timeout(1), symbol("["), overlay("/"), button_tx(false) {}
 
 		String message;
 		int timeout;
 		String symbol;
 		String overlay; 
+		bool button_tx;
 	};
 
 	class Smart_Beacon

--- a/src/pins.h
+++ b/src/pins.h
@@ -9,6 +9,8 @@
 #define OLED_SCL	22
 #define OLED_RST	16
 
+#define BUTTON_PIN 38 // The middle button GPIO on the T-Beam
+
 #ifdef TTGO_T_Beam_V0_7
 	#define GPS_RX	15
 	#define GPS_TX	12


### PR DESCRIPTION
Allow manual TXing using the middle GPIO button on the T-Beam.

By enabling the `Config.beacon.button_tx` setting, users will be able to manually trigger the beacon, if all the other update conditions are met (GPS location fixed, etc.).

Tested with T-Beam V1 and with a TTGO LoRa32 as the [iGate](https://github.com/peterus/LoRa_APRS_iGate)

Used the Arduino OneButton library (found it to be successfully used in other projects on T-Beam):
https://github.com/geeksville/OneButton.git