### PR TITLE
Added support for multiple alternative messages/callsigns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+.vscode/settings.json

--- a/data/tracker.json
+++ b/data/tracker.json
@@ -1,41 +1,42 @@
 {
-	"callsign":"NOCALL-7",
 	"debug": false,
 	"enhance_precision": true,
-	"beacon":
-	{
-		"message":"LoRa Tracker",
-		"timeout": 1,
-		"button_tx": false,
-		"symbol": "[",
-		"overlay": "/"
+	"beacons": [
+		{
+			"callsign": "NOCALL-7",
+			"message": "LoRa Tracker",
+			"timeout": 1,
+			"symbol": "[",
+			"overlay": "/"
+		}
+	],
+	"button": {
+		"tx": true,
+		"alt_message": true
 	},
-	"smart_beacon":
-	{
-		"active":true,
-		"turn_min":25,
-		"slow_rate":300,
-		"slow_speed":10,
-		"fast_rate":60,
-		"fast_speed":100,
-		"min_tx_dist":100,
-		"min_bcn":5
+	"smart_beacon": {
+		"active": true,
+		"turn_min": 25,
+		"slow_rate": 300,
+		"slow_speed": 10,
+		"fast_rate": 60,
+		"fast_speed": 100,
+		"min_tx_dist": 100,
+		"min_bcn": 5,
 	},
-	"lora":
-	{
-		"frequency_rx":433775000,
-		"frequency_tx":433775000,
-		"power":20,
-		"spreading_factor":12,
-		"signal_bandwidth":125000,
-		"coding_rate4":5
+	"lora": {
+		"frequency_rx": 433775000,
+		"frequency_tx": 433775000,
+		"power": 20,
+		"spreading_factor": 12,
+		"signal_bandwidth": 125000,
+		"coding_rate4": 5
 	},
-	"ptt_output":
-	{
-		"active":false,
+	"ptt_output": {
+		"active": false,
 		"io_pin": 4,
 		"start_delay": 0,
 		"end_delay": 0,
-		"reverse":false
+		"reverse": false
 	}
 }

--- a/data/tracker.json
+++ b/data/tracker.json
@@ -1,6 +1,5 @@
 {
 	"debug": false,
-	"enhance_precision": true,
 	"beacons": [
 		{
 			"callsign": "NOCALL-7",
@@ -8,22 +7,23 @@
 			"message": "LoRa Tracker",
 			"timeout": 1,
 			"symbol": "[",
-			"overlay": "/"
+			"overlay": "/",
+			"smart_beacon": {
+				"active": true,
+				"turn_min": 25,
+				"slow_rate": 300,
+				"slow_speed": 10,
+				"fast_rate": 60,
+				"fast_speed": 100,
+				"min_tx_dist": 100,
+				"min_bcn": 5
+			},
+			"enhance_precision": true
 		}
 	],
 	"button": {
 		"tx": true,
 		"alt_message": true
-	},
-	"smart_beacon": {
-		"active": true,
-		"turn_min": 25,
-		"slow_rate": 300,
-		"slow_speed": 10,
-		"fast_rate": 60,
-		"fast_speed": 100,
-		"min_tx_dist": 100,
-		"min_bcn": 5
 	},
 	"lora": {
 		"frequency_rx": 433775000,

--- a/data/tracker.json
+++ b/data/tracker.json
@@ -1,23 +1,21 @@
 {
 	"debug": false,
 	"enhance_precision": true,
-	"beacons": 
-	[
+	"beacons": [
 		{
 			"callsign": "NOCALL-7",
+			"path": "WIDE1-1",
 			"message": "LoRa Tracker",
 			"timeout": 1,
 			"symbol": "[",
 			"overlay": "/"
 		}
 	],
-	"button": 
-	{
+	"button": {
 		"tx": true,
 		"alt_message": true
 	},
-	"smart_beacon": 
-	{
+	"smart_beacon": {
 		"active": true,
 		"turn_min": 25,
 		"slow_rate": 300,
@@ -27,8 +25,7 @@
 		"min_tx_dist": 100,
 		"min_bcn": 5
 	},
-	"lora": 
-	{
+	"lora": {
 		"frequency_rx": 433775000,
 		"frequency_tx": 433775000,
 		"power": 20,
@@ -36,8 +33,7 @@
 		"signal_bandwidth": 125000,
 		"coding_rate4": 5
 	},
-	"ptt_output": 
-	{
+	"ptt_output": {
 		"active": false,
 		"io_pin": 4,
 		"start_delay": 0,

--- a/data/tracker.json
+++ b/data/tracker.json
@@ -1,7 +1,8 @@
 {
 	"debug": false,
 	"enhance_precision": true,
-	"beacons": [
+	"beacons": 
+	[
 		{
 			"callsign": "NOCALL-7",
 			"message": "LoRa Tracker",
@@ -10,11 +11,13 @@
 			"overlay": "/"
 		}
 	],
-	"button": {
+	"button": 
+	{
 		"tx": true,
 		"alt_message": true
 	},
-	"smart_beacon": {
+	"smart_beacon": 
+	{
 		"active": true,
 		"turn_min": 25,
 		"slow_rate": 300,
@@ -22,9 +25,10 @@
 		"fast_rate": 60,
 		"fast_speed": 100,
 		"min_tx_dist": 100,
-		"min_bcn": 5,
+		"min_bcn": 5
 	},
-	"lora": {
+	"lora": 
+	{
 		"frequency_rx": 433775000,
 		"frequency_tx": 433775000,
 		"power": 20,
@@ -32,7 +36,8 @@
 		"signal_bandwidth": 125000,
 		"coding_rate4": 5
 	},
-	"ptt_output": {
+	"ptt_output": 
+	{
 		"active": false,
 		"io_pin": 4,
 		"start_delay": 0,

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,3 +1,5 @@
+[platformio]
+default_envs = ttgo-t-beam-v1
 
 [env]
 platform = espressif32 @ 3.0.0

--- a/src/BeaconManager.cpp
+++ b/src/BeaconManager.cpp
@@ -1,0 +1,23 @@
+#include "BeaconManager.h"
+
+BeaconManager::BeaconManager() : _currentBeaconConfig(_beacon_config.end()) {
+}
+
+// cppcheck-suppress unusedFunction
+void BeaconManager::loadConfig(const std::list<Configuration::Beacon> &beacon_config) {
+  _beacon_config       = beacon_config;
+  _currentBeaconConfig = _beacon_config.begin();
+}
+
+// cppcheck-suppress unusedFunction
+std::list<Configuration::Beacon>::iterator BeaconManager::getCurrentBeaconConfig() const {
+  return _currentBeaconConfig;
+}
+
+// cppcheck-suppress unusedFunction
+void BeaconManager::loadNextBeacon() {
+  ++_currentBeaconConfig;
+  if (_currentBeaconConfig == _beacon_config.end()) {
+    _currentBeaconConfig = _beacon_config.begin();
+  }
+}

--- a/src/BeaconManager.h
+++ b/src/BeaconManager.h
@@ -1,0 +1,20 @@
+#ifndef BEACON_MANAGER_H_
+#define BEACON_MANAGER_H_
+
+#include "configuration.h"
+
+class BeaconManager {
+public:
+  BeaconManager();
+
+  void loadConfig(const std::list<Configuration::Beacon> &beacon_config);
+
+  std::list<Configuration::Beacon>::iterator getCurrentBeaconConfig() const;
+  void                                       loadNextBeacon();
+
+private:
+  std::list<Configuration::Beacon>           _beacon_config;
+  std::list<Configuration::Beacon>::iterator _currentBeaconConfig;
+};
+
+#endif

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -187,14 +187,14 @@ void loop() {
 
   if (send_update && gps_loc_update) {
     send_update         = false;
-    nextBeaconTimeStamp = now() + (Config.smart_beacon.active ? Config.smart_beacon.slow_rate : (Config.GetCurrentBeacon().timeout * SECS_PER_MIN));
+    Configuration::Beacon beacon = Config.GetCurrentBeacon();
+
+    nextBeaconTimeStamp = now() + (Config.smart_beacon.active ? Config.smart_beacon.slow_rate : (beacon.timeout * SECS_PER_MIN));
 
     APRSMessage msg;
     String      lat;
     String      lng;
     String      dao;
-
-    Configuration::Beacon beacon = Config.GetCurrentBeacon();
 
     msg.setSource(beacon.callsign);
     msg.setDestination("APLT00-1");

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -186,7 +186,7 @@ void loop() {
   }
 
   if (send_update && gps_loc_update) {
-    send_update         = false;
+    send_update                  = false;
     Configuration::Beacon beacon = Config.GetCurrentBeacon();
 
     nextBeaconTimeStamp = now() + (Config.smart_beacon.active ? Config.smart_beacon.slow_rate : (beacon.timeout * SECS_PER_MIN));
@@ -197,6 +197,7 @@ void loop() {
     String      dao;
 
     msg.setSource(beacon.callsign);
+    msg.setPath(beacon.path);
     msg.setDestination("APLT00-1");
 
     if (!Config.enhance_precision) {

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -43,6 +43,8 @@ Configuration ConfigurationManagement::readConfiguration() {
 
     if (v.containsKey("callsign"))
       beacon.callsign = v["callsign"].as<String>();
+    if (v.containsKey("path"))
+      beacon.path = v["path"].as<String>();
     if (v.containsKey("message"))
       beacon.message = v["message"].as<String>();
     beacon.timeout = v["timeout"] | 1;
@@ -62,9 +64,9 @@ Configuration ConfigurationManagement::readConfiguration() {
   conf.smart_beacon.fast_speed  = data["smart_beacon"]["fast_speed"] | 100;
   conf.smart_beacon.min_tx_dist = data["smart_beacon"]["min_tx_dist"] | 100;
   conf.smart_beacon.min_bcn     = data["smart_beacon"]["min_bcn"] | 5;
-  
-  conf.button.tx            = data["button"]["tx"] | false;
-  conf.button.alt_message   = data["button"]["alt_message"] | false;
+
+  conf.button.tx          = data["button"]["tx"] | false;
+  conf.button.alt_message = data["button"]["alt_message"] | false;
 
   conf.lora.frequencyRx     = data["lora"]["frequency_rx"] | 433775000;
   conf.lora.frequencyTx     = data["lora"]["frequency_tx"] | 433775000;
@@ -95,17 +97,18 @@ void ConfigurationManagement::writeConfiguration(Configuration conf) {
   for (Configuration::Beacon beacon : conf.beacons) {
     JsonObject v  = beacons.createNestedObject();
     v["callsign"] = beacon.callsign;
+    v["path"]     = beacon.path;
     v["message"]  = beacon.message;
     v["timeout"]  = beacon.timeout;
     v["symbol"]   = beacon.symbol;
     v["overlay"]  = beacon.overlay;
   }
 
-  data["debug"]                       = conf.debug;
-  data["enhance_precision"]           = conf.enhance_precision;
+  data["debug"]             = conf.debug;
+  data["enhance_precision"] = conf.enhance_precision;
 
-  data["button"]["tx"]                = conf.button.tx;
-  data["button"]["alt_message"]       = conf.button.alt_message;
+  data["button"]["tx"]          = conf.button.tx;
+  data["button"]["alt_message"] = conf.button.alt_message;
 
   data["smart_beacon"]["active"]      = conf.smart_beacon.active;
   data["smart_beacon"]["turn_min"]    = conf.smart_beacon.turn_min;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -34,8 +34,7 @@ Configuration ConfigurationManagement::readConfiguration() {
 
   Configuration conf;
 
-  conf.debug             = data["debug"] | false;
-  conf.enhance_precision = data["enhance_precision"] | false;
+  conf.debug = data["debug"] | false;
 
   JsonArray beacons = data["beacons"].as<JsonArray>();
   for (JsonVariant v : beacons) {
@@ -53,17 +52,19 @@ Configuration ConfigurationManagement::readConfiguration() {
     if (v.containsKey("overlay"))
       beacon.overlay = v["overlay"].as<String>();
 
+    beacon.smart_beacon.active      = v["smart_beacon"]["active"] | false;
+    beacon.smart_beacon.turn_min    = v["smart_beacon"]["turn_min"] | 25;
+    beacon.smart_beacon.slow_rate   = v["smart_beacon"]["slow_rate"] | 300;
+    beacon.smart_beacon.slow_speed  = v["smart_beacon"]["slow_speed"] | 10;
+    beacon.smart_beacon.fast_rate   = v["smart_beacon"]["fast_rate"] | 60;
+    beacon.smart_beacon.fast_speed  = v["smart_beacon"]["fast_speed"] | 100;
+    beacon.smart_beacon.min_tx_dist = v["smart_beacon"]["min_tx_dist"] | 100;
+    beacon.smart_beacon.min_bcn     = v["smart_beacon"]["min_bcn"] | 5;
+
+    beacon.enhance_precision = v["enhance_precision"] | false;
+
     conf.beacons.push_back(beacon);
   }
-
-  conf.smart_beacon.active      = data["smart_beacon"]["active"] | false;
-  conf.smart_beacon.turn_min    = data["smart_beacon"]["turn_min"] | 25;
-  conf.smart_beacon.slow_rate   = data["smart_beacon"]["slow_rate"] | 300;
-  conf.smart_beacon.slow_speed  = data["smart_beacon"]["slow_speed"] | 10;
-  conf.smart_beacon.fast_rate   = data["smart_beacon"]["fast_rate"] | 60;
-  conf.smart_beacon.fast_speed  = data["smart_beacon"]["fast_speed"] | 100;
-  conf.smart_beacon.min_tx_dist = data["smart_beacon"]["min_tx_dist"] | 100;
-  conf.smart_beacon.min_bcn     = data["smart_beacon"]["min_bcn"] | 5;
 
   conf.button.tx          = data["button"]["tx"] | false;
   conf.button.alt_message = data["button"]["alt_message"] | false;
@@ -102,22 +103,23 @@ void ConfigurationManagement::writeConfiguration(Configuration conf) {
     v["timeout"]  = beacon.timeout;
     v["symbol"]   = beacon.symbol;
     v["overlay"]  = beacon.overlay;
+
+    v["smart_beacon"]["active"]      = beacon.smart_beacon.active;
+    v["smart_beacon"]["turn_min"]    = beacon.smart_beacon.turn_min;
+    v["smart_beacon"]["slow_rate"]   = beacon.smart_beacon.slow_rate;
+    v["smart_beacon"]["slow_speed"]  = beacon.smart_beacon.slow_speed;
+    v["smart_beacon"]["fast_rate"]   = beacon.smart_beacon.fast_rate;
+    v["smart_beacon"]["fast_speed"]  = beacon.smart_beacon.fast_speed;
+    v["smart_beacon"]["min_tx_dist"] = beacon.smart_beacon.min_tx_dist;
+    v["smart_beacon"]["min_bcn"]     = beacon.smart_beacon.min_bcn;
+
+    v["enhance_precision"] = beacon.enhance_precision;
   }
 
-  data["debug"]             = conf.debug;
-  data["enhance_precision"] = conf.enhance_precision;
+  data["debug"] = conf.debug;
 
   data["button"]["tx"]          = conf.button.tx;
   data["button"]["alt_message"] = conf.button.alt_message;
-
-  data["smart_beacon"]["active"]      = conf.smart_beacon.active;
-  data["smart_beacon"]["turn_min"]    = conf.smart_beacon.turn_min;
-  data["smart_beacon"]["slow_rate"]   = conf.smart_beacon.slow_rate;
-  data["smart_beacon"]["slow_speed"]  = conf.smart_beacon.slow_speed;
-  data["smart_beacon"]["fast_rate"]   = conf.smart_beacon.fast_rate;
-  data["smart_beacon"]["fast_speed"]  = conf.smart_beacon.fast_speed;
-  data["smart_beacon"]["min_tx_dist"] = conf.smart_beacon.min_tx_dist;
-  data["smart_beacon"]["min_bcn"]     = conf.smart_beacon.min_bcn;
 
   data["lora"]["frequency_rx"]     = conf.lora.frequencyRx;
   data["lora"]["frequency_tx"]     = conf.lora.frequencyTx;
@@ -134,17 +136,4 @@ void ConfigurationManagement::writeConfiguration(Configuration conf) {
 
   serializeJson(data, file);
   file.close();
-}
-
-Configuration::Beacon Configuration::GetCurrentBeacon() {
-  auto iterator = this->beacons.begin();
-  std::advance(iterator, this->current_beacon_index);
-  return *iterator;
-}
-
-Configuration::Beacon Configuration::SetNextBeacon() {
-  this->current_beacon_index++;
-  if (this->current_beacon_index >= this->beacons.size())
-    this->current_beacon_index = 0;
-  return this->GetCurrentBeacon();
 }

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -1,8 +1,8 @@
 #ifndef CONFIGURATION_H_
 #define CONFIGURATION_H_
 
-#include <list>
 #include <iterator>
+#include <list>
 
 #include <Arduino.h>
 
@@ -10,10 +10,11 @@ class Configuration {
 public:
   class Beacon {
   public:
-    Beacon() : callsign("NOCALL-10"), message("LoRa Tracker, Info: github.com/lora-aprs/LoRa_APRS_Tracker"), timeout(1), symbol("["), overlay("/") {
+    Beacon() : callsign("NOCALL-10"), path("WIDE1-1"), message("LoRa Tracker"), timeout(1), symbol("["), overlay("/") {
     }
 
     String callsign;
+    String path;
     String message;
     int    timeout;
     String symbol;
@@ -69,16 +70,16 @@ public:
     int  alt_message;
   };
 
-  Configuration() : debug(false), enhance_precision(true), current_beacon_index(0) {};
+  Configuration() : debug(false), enhance_precision(true), current_beacon_index(0){};
 
-  bool                debug;
-  bool                enhance_precision;
-  std::list<Beacon>   beacons;
-  int                 current_beacon_index;
-  Smart_Beacon        smart_beacon;
-  LoRa                lora;
-  PTT                 ptt;
-  Button              button;
+  bool              debug;
+  bool              enhance_precision;
+  std::list<Beacon> beacons;
+  int               current_beacon_index;
+  Smart_Beacon      smart_beacon;
+  LoRa              lora;
+  PTT               ptt;
+  Button            button;
 
   Beacon GetCurrentBeacon();
   Beacon SetNextBeacon();

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -10,31 +10,32 @@ class Configuration {
 public:
   class Beacon {
   public:
-    Beacon() : callsign("NOCALL-10"), path("WIDE1-1"), message("LoRa Tracker"), timeout(1), symbol("["), overlay("/") {
+    class Smart_Beacon {
+    public:
+      Smart_Beacon() : active(false), turn_min(25), slow_rate(300), slow_speed(10), fast_rate(60), fast_speed(100), min_tx_dist(100), min_bcn(5) {
+      }
+
+      bool active;
+      int  turn_min;
+      int  slow_rate;
+      int  slow_speed;
+      int  fast_rate;
+      int  fast_speed;
+      int  min_tx_dist;
+      int  min_bcn;
+    };
+
+    Beacon() : callsign("NOCALL-10"), path("WIDE1-1"), message("LoRa Tracker"), timeout(1), symbol("["), overlay("/"), enhance_precision(true) {
     }
 
-    String callsign;
-    String path;
-    String message;
-    String path;
-    int    timeout;
-    String symbol;
-    String overlay;
-  };
-
-  class Smart_Beacon {
-  public:
-    Smart_Beacon() : active(false), turn_min(25), slow_rate(300), slow_speed(10), fast_rate(60), fast_speed(100), min_tx_dist(100), min_bcn(5) {
-    }
-
-    bool active;
-    int  turn_min;
-    int  slow_rate;
-    int  slow_speed;
-    int  fast_rate;
-    int  fast_speed;
-    int  min_tx_dist;
-    int  min_bcn;
+    String       callsign;
+    String       path;
+    String       message;
+    int          timeout;
+    String       symbol;
+    String       overlay;
+    Smart_Beacon smart_beacon;
+    bool         enhance_precision;
   };
 
   class LoRa {
@@ -71,19 +72,14 @@ public:
     int  alt_message;
   };
 
-  Configuration() : debug(false), enhance_precision(true), current_beacon_index(0){};
+  Configuration() : debug(false) {
+  }
 
   bool              debug;
-  bool              enhance_precision;
   std::list<Beacon> beacons;
-  int               current_beacon_index;
-  Smart_Beacon      smart_beacon;
   LoRa              lora;
   PTT               ptt;
   Button            button;
-
-  Beacon GetCurrentBeacon();
-  Beacon SetNextBeacon();
 };
 
 class ConfigurationManagement {

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -2,6 +2,7 @@
 #define CONFIGURATION_H_
 
 #include <list>
+#include <iterator>
 
 #include <Arduino.h>
 
@@ -9,14 +10,14 @@ class Configuration {
 public:
   class Beacon {
   public:
-    Beacon() : message("LoRa Tracker, Info: github.com/lora-aprs/LoRa_APRS_Tracker"), timeout(1), symbol("["), overlay("/"), button_tx(false) {
+    Beacon() : callsign("NOCALL-10"), message("LoRa Tracker, Info: github.com/lora-aprs/LoRa_APRS_Tracker"), timeout(1), symbol("["), overlay("/") {
     }
 
+    String callsign;
     String message;
     int    timeout;
     String symbol;
     String overlay;
-    bool   button_tx;
   };
 
   class Smart_Beacon {
@@ -59,15 +60,28 @@ public:
     bool reverse;
   };
 
-  Configuration() : callsign("NOCALL-10"), debug(false), enhance_precision(true){};
+  class Button {
+  public:
+    Button() : tx(false), alt_message(false) {
+    }
 
-  String       callsign;
-  bool         debug;
-  bool         enhance_precision;
-  Beacon       beacon;
-  Smart_Beacon smart_beacon;
-  LoRa         lora;
-  PTT          ptt;
+    bool tx;
+    int  alt_message;
+  };
+
+  Configuration() : debug(false), enhance_precision(true), current_beacon_index(0) {};
+
+  bool                debug;
+  bool                enhance_precision;
+  std::list<Beacon>   beacons;
+  int                 current_beacon_index;
+  Smart_Beacon        smart_beacon;
+  LoRa                lora;
+  PTT                 ptt;
+  Button              button;
+
+  Beacon GetCurrentBeacon();
+  Beacon SetNextBeacon();
 };
 
 class ConfigurationManagement {


### PR DESCRIPTION
As per #45 
- moved `button_tx` to separate `button` config subitem and added `alt_message` option (both set to true by default)
- added support for multiple callsigns / messages / icons / overlays (switch by holding the middle button)
- made `beacons` JSON config to be an array (you can add as much beacon configs as you want)