### PR TITLE
Fixes for to u-blox M8N  based T-beam without display and small power saving

### DIFF
--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -136,10 +136,10 @@ void loop() {
   static bool   gps_loc_update_valid = false;
   static time_t nextBeaconTimeStamp  = -1;
 
-  if (gps_loc_update != gps_loc_update_valid) {
-    gps_loc_update_valid = gps_loc_update;
+  if (gps.location.isValid() != gps_loc_update_valid) {
+    gps_loc_update_valid = gps.location.isValid();
 
-    if (gps_loc_update) {
+    if (gps_loc_update_valid) {
       logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "Loop", "GPS fix state went to VALID");
     } else {
       logger.log(logging::LoggerLevel::LOGGER_LEVEL_INFO, "Loop", "GPS fix state went to INVALID");

--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -402,6 +402,7 @@ void setup_lora() {
 
 void setup_gps() {
   ss.begin(9600, SERIAL_8N1, GPS_TX, GPS_RX);
+  ss.println(); //GPS seems to have problems if the line is not initialized
 }
 
 char *s_min_nn(uint32_t min_nnnnn, int high_precision) {


### PR DESCRIPTION
This PR contains 2 fixes and one improvement, feel free to cherry-pick whatever seems of interest:
- The GPS validity checking in present version uses wrong method for logging, which at least on M8N caused serial log being flooded with GPS fix state went to VALID and GPS fix state went to INVALID messages each second
- The GPS port has been stuck in incorrect state after detection which generated error message from GPS and disabling the RX on it
- Probably the biggest change is the improvement to reduce the CPU clock to 40 MHz, if possible. So far this has been tested on 2 different V1 T-beams without any problem, but maybe further testing with older devices may be necessary?  The power consumption is decreased by about 15mA-18mA (the de-powering of ADC is deprecated in newer versions of SDK, so I have removed that from changes)  