### PR TITLE
String Object needs to be converted to C-style null terminated string…

### DIFF
--- a/src/LoRa_APRS_Tracker.cpp
+++ b/src/LoRa_APRS_Tracker.cpp
@@ -295,7 +295,7 @@ void loop() {
 
     msg.getBody()->setData(aprsmsg);
     String data = msg.encode();
-    logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "Loop", "%s", data);
+    logger.log(logging::LoggerLevel::LOGGER_LEVEL_DEBUG, "Loop", "%s", data.c_str());
     show_display("<< TX >>", data);
 
     if (Config.ptt.active) {


### PR DESCRIPTION
Used logger class accept c-style string instead of String objects. c_str function converts String object to null terminated string