### PR TITLE
Bump Adafruit SSD1306 from 2.5.7 to 2.5.10

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 lib_deps = 
 	adafruit/Adafruit GFX Library @ 1.11.7
-	adafruit/Adafruit SSD1306 @ 2.5.7
+	adafruit/Adafruit SSD1306 @ 2.5.10
 	bblanchon/ArduinoJson @ 6.21.3
 	lewisxhe/XPowersLib @ 0.1.8
 	sandeepmistry/LoRa @ 0.8.0


### PR DESCRIPTION
Bump Adafruit SSD1306 from 2.5.7 to 2.5.10